### PR TITLE
[Setup] capitalize h2 in speaker profile - languages

### DIFF
--- a/src/components/Speaker/index.tsx
+++ b/src/components/Speaker/index.tsx
@@ -101,7 +101,7 @@ export default function Speaker({
         </ul>
         <h2>Willing to provide coaching and advice to new speakers</h2>
         <p>{coachNewSpeakers}</p>
-        <h2>languages</h2>
+        <h2>Languages</h2>
         <p>
           {languages.map((language) => (
             <span key={language} className={styles.language}>


### PR DESCRIPTION
In the speaker profiles, the heading of the languages section starts with a small l. Let's capitalize it.