### PR TITLE
[Setup] Add padding to role and company

### DIFF
--- a/src/components/Speaker/styles.module.css
+++ b/src/components/Speaker/styles.module.css
@@ -39,11 +39,13 @@
   font-size: 16px;
   color: var(--ifm-color-content);
   display: block;
+  padding: 15px;
 }
 .company {
   font-size: 14px;
   color: var(--ifm-color-emphasis-700);
   display: block;
+  padding: 15px;
 }
 .social {
   display: flex;


### PR DESCRIPTION
Hi Osama, could you add some padding to the grey block on the right side of the speaker profiles? We need this especially when someone has a long text in the **role** and/or **company** fields. Too much text looks odd here, see for example [Abhishek's profile here](https://speakers.greensoftware.foundation/speakers/abhishek-gupta). 

Some padding on all fours sides might be good, but feel free to adjust as you see fit. Thanks.